### PR TITLE
Make register.html output more readable for long bit names

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'https://rubygems.org'
+source 'http://rubygems.org'
 
 # Specify your gem's dependencies in origen_doc_helpers.gemspec
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       origen (>= 0.7.15)
 
 GEM
-  remote: https://rubygems.org/
+  remote: http://rubygems.org/
   specs:
     activesupport (4.2.8)
       i18n (~> 0.7)

--- a/templates/shared/_register.html.erb
+++ b/templates/shared/_register.html.erb
@@ -71,9 +71,9 @@
 %         bit_name = "#{name}[#{bit.size - 1}:0]"
       <td class="<%= _bit_rw(bit) %>" colspan="<%= _num_bits_in_range(bit, max_bit, min_bit) %>">
 % if options[:descriptions] && !bit.description.empty?
-         <span><a href="#<%= "#{reg.name}_#{name}_#{bit.position}" %>"><%= bit_name %></a></span>
+         <span title="<%= name %>"><a href="#<%= "#{reg.name}_#{name}_#{bit.position}" %>"><%= bit_name %></a></span>
 % else
-         <span><%= bit_name %></span>
+         <span title="<%= name %>"><%= bit_name %></span>
 % end
       </td>
 %       else
@@ -95,10 +95,16 @@
 %   else
 %     if name
 %       if bit.readable?
-%         if options[:descriptions] && !bit.description.empty?
-      <td class="<%= _bit_rw(bit) %>"><span><a href="#<%= "#{reg.name}_#{name}_#{bit.position}" %>"><%= name %></a></span></td>
+%         if name.size > 10
+%           bit_name = "#{name[0..2]}...#{name[-3..-1]}"
+%#           bit_name = "bit#{bit.position}*"
 %         else
-      <td class="<%= _bit_rw(bit) %>"><span><%= name %></span></td>
+%           bit_name = name
+%         end
+%         if options[:descriptions] && !bit.description.empty?
+      <td class="<%= _bit_rw(bit) %>"><span title="<%= name %>"><a href="#<%= "#{reg.name}_#{name}_#{bit.position}" %>"><%= bit_name %></a></span></td>
+%         else
+      <td class="<%= _bit_rw(bit) %>"><span title="<%= name %>"><%= bit_name %></span></td>
 %         end
 %       else
       <td class="<%= _bit_rw(bit) %>"></td>
@@ -131,9 +137,9 @@
 %         bit_name = "#{name}[#{bit.size - 1}:0]"
       <td class="<%= _bit_rw(bit) %>" colspan="<%= _num_bits_in_range(bit, max_bit, min_bit) %>">
 % if options[:descriptions] && !bit.description.empty?
-         <span><a href="#<%= "#{reg.name}_#{name}_#{bit.position}" %>"><%= bit_name %></a></span>
+         <span title="<%= name %>"><a href="#<%= "#{reg.name}_#{name}_#{bit.position}" %>"><%= bit_name %></a></span>
 % else
-         <span><%= bit_name %></span>
+         <span title="<%= name %>"><%= bit_name %></span>
 % end
       </td>
 %       else
@@ -149,10 +155,16 @@
 %   else
 %     if name
 %       if !bit.readable?
-%         if options[:descriptions] && !bit.description.empty?
-      <td class="<%= _bit_rw(bit) %>"><span><a href="#<%= "#{reg.name}_#{name}_#{bit.position}" %>"><%= name %></a></span></td>
+%         if name.size > 10
+%           bit_name = "#{name[0..2]}...#{name[-3..-1]}"
+%#           bit_name = "bit#{bit.position}*"
 %         else
-      <td class="<%= _bit_rw(bit) %>"><span><%= name %></span></td>
+%           bit_name = name
+%         end
+%         if options[:descriptions] && !bit.description.empty?
+      <td class="<%= _bit_rw(bit) %>"><span title="<%= name %>"><a href="#<%= "#{reg.name}_#{name}_#{bit.position}" %>"><%= bit_name %></a></span></td>
+%         else
+      <td class="<%= _bit_rw(bit) %>"><span title="<%= name %>"><%= bit_name %></span></td>
 %         end
 %       else
       <td class="<%= _bit_rw(bit) %>"></td>


### PR DESCRIPTION
For single bits that have long bit names (> 10 chars), reduce text to = (first 3 chars)...(last 3 chars) (eg. abc...xyz).

Also add a tooltip that will pop up with the full bit name when the bit name is hovered over with the mouse.