### PR TITLE
Msb0 update - additional info and formatting to avoid confusion

### DIFF
--- a/lib/origen_doc_helpers_dev/dut.rb
+++ b/lib/origen_doc_helpers_dev/dut.rb
@@ -79,18 +79,23 @@ module OrigenDocHelpersDev
           bit 31..0, :placeholder, reset: 0b0, access: :rw
         end
         reg :msb0_debug, 0xf58, 32, bit_order: 'msb0', ip_base_address: 0x1080000, description: '' do
-          bit 31..0, :placeholder, reset: 0b0, access: :rw
+          # placeholder field description
+          bit 31..1, :placeholder, reset: 0b0, access: :rw
+          # single bit
+          bit 0,     :single_bit, reset: 1, access: :rw
         end
         reg :lsb0_non_byte_aligned, 0xf5c, 9, bit_order: 'lsb0', ip_base_address: 0x1080000, description: '' do
           bit 8..0, :placeholder, reset: 0b0, access: :rw
         end
         reg :msb0_non_byte_aligned, 0xf60, 9, bit_order: :msb0, ip_base_address: 0x1080000, description: '' do
+          # placeholder field description
           bit 8..0, :placeholder, reset: 0b0, access: :rw
         end
         reg :lsb0_tiny, 0xf64, 3, bit_order: :lsb0, ip_base_address: 0x1080000, description: '' do
           bit 2..0, :placeholder, reset: 0b0, access: :rw
         end
         reg :msb0_tiny, 0xf68, 3, bit_order: :msb0, ip_base_address: 0x1080000, description: '' do
+          # placeholder field description
           bit 2..0, :placeholder, reset: 0b0, access: :rw
         end
       end

--- a/templates/shared/_register.html.erb
+++ b/templates/shared/_register.html.erb
@@ -320,16 +320,16 @@
         <p>
           <a class="anchor" name="<%= "#{reg.name}_#{name}_#{bits.position}" %>"></a>
 % if bits.size == 1        
-          <%= bits.position %><%= order_is_lsb0 ? '' : " (#{reg.size - bits.position - 1})" %>
+          <%= bits.position %><%= order_is_lsb0 ? '' : "<span class=\"msb0_specific\" style=\"color:gray;\"> (#{reg.size - bits.position - 1})</span>" %>
 % else
-          <%= bits.position + bits.size - 1 %>-<%= bits.position %><%= order_is_lsb0 ? '' : " (#{reg.size - bits.position - bits.size}-#{reg.size - bits.position - 1})" %>
+          <%= bits.position + bits.size - 1 %>-<%= bits.position %><%= order_is_lsb0 ? '' : "<span class=\"msb0_specific\" style=\"color:gray;\"> (#{reg.size - bits.position - bits.size}-#{reg.size - bits.position - 1})</span>" %>
 % end
         </p>
         <p>
 % if bits.size == 1        
           <%= name %>
 % else
-          <%= name %>[<%= bits.size - 1 %>:0]<%= order_is_lsb0 ? '' : " ([0:#{bits.size - 1}])" %>
+          <%= name %>[<%= bits.size - 1 %>:0]<%= order_is_lsb0 ? '' : "<span class=\"msb0_specific\" style=\"color:gray;\"> ([0:#{bits.size - 1}])</span>" %>
 % end
         </p>
       </td>

--- a/templates/shared/_register.html.erb
+++ b/templates/shared/_register.html.erb
@@ -60,7 +60,11 @@
 <table class="reg table table-condensed <%= 'rjust' %><%= partial_byte ? ' partial' : '' %>" style="margin-bottom: 0; table-layout: fixed;">
   <thead>
     <tr class="bit-positions">
+% if order_is_lsb0
       <th class="spacer"></th>
+% else
+      <td class="heading">LSB0<span class="msb0_specific" style="color:red;"> (MSB0)</span></td>
+% end
 
 % 8.times do |i|
 %   bit_num = (byte_number * 8) - i - 1
@@ -70,7 +74,7 @@
 %     if order_is_lsb0
       <th class="bit-position"><%= bit_num %></th>
 %     else
-      <th class="bit-position"><%= bit_num %><span class="msb0_specific"> (<%= reg.size - bit_num -1%>)</span></th>
+      <th class="bit-position"><%= bit_num %><span class="msb0_specific" style="color:red;"> (<%= reg.size - bit_num -1%>)</span></th>
 %     end
 %   end
 % end
@@ -85,7 +89,7 @@
 % if order_is_lsb0
       <td class="heading">R</td>
 % else
-      <td class="heading">R<span class="msb0_specific"> [LSB0]</span></td>
+      <td class="heading"><span class="msb0_specific" style="color:red;">[LSB0] </span>R</td>
 % end
 
 % alignment_done = false

--- a/templates/shared/_register.html.erb
+++ b/templates/shared/_register.html.erb
@@ -320,16 +320,16 @@
         <p>
           <a class="anchor" name="<%= "#{reg.name}_#{name}_#{bits.position}" %>"></a>
 % if bits.size == 1        
-          <%= bits.position %>
+          <%= bits.position %><%= order_is_lsb0 ? '' : " (#{reg.size - bits.position - 1})" %>
 % else
-          <%= bits.position + bits.size - 1 %>-<%= bits.position %>
+          <%= bits.position + bits.size - 1 %>-<%= bits.position %><%= order_is_lsb0 ? '' : " (#{reg.size - bits.position - bits.size}-#{reg.size - bits.position - 1})" %>
 % end
         </p>
         <p>
 % if bits.size == 1        
           <%= name %>
 % else
-          <%= name %>[<%= bits.size - 1 %>:0]
+          <%= name %>[<%= bits.size - 1 %>:0]<%= order_is_lsb0 ? '' : " ([0:#{bits.size - 1}])" %>
 % end
         </p>
       </td>

--- a/templates/shared/_register.html.erb
+++ b/templates/shared/_register.html.erb
@@ -14,9 +14,17 @@
 %   reg_path = reg.name
 % end
 % if reg.full_name
+%   if order_is_lsb0
 <h4>0x<%= reg.address.to_s(16).upcase %> - <%= reg.full_name %> (<%= reg_path %>)</h4>
+%   else
+<h4>0x<%= reg.address.to_s(16).upcase %> - <%= reg.full_name %> (<%= reg_path %>)<span class="msb0_specific"> <%= "#{reg_path}.with_msb0"%>(to access using MSB0 numbering)</span></h4>
+%   end
 % else
+%   if order_is_lsb0
 <h4>0x<%= reg.address.to_s(16).upcase %> - <%= reg_path %></h4>
+%   else
+<h4>0x<%= reg.address.to_s(16).upcase %> - <%= reg_path %><span class="msb0_specific"> <%= "#{reg_path}.with_msb0"%>(to access using MSB0 numbering)</span></h4>
+%   end
 % end
 </a>
 % if options[:current_value]
@@ -45,29 +53,25 @@
 % num_bytes.times do |byte_index|
 %   # Need to add support for little endian regs here?
 %   byte_number = num_bytes - byte_index
-%   if order_is_lsb0
-%     max_bit = (byte_number * 8) - 1
-%     min_bit = max_bit - 8 + 1
-%   else
-%     min_bit = (byte_index * 8)
-%     max_bit = min_bit + 7
-%   end
+%   max_bit = (byte_number * 8) - 1
+%   min_bit = max_bit - 8 + 1
 %   partial_byte = max_bit > (reg.size - 1)
 
-<table class="reg table table-condensed <%= order_is_lsb0 ? 'rjust' : 'ljust' %><%= partial_byte ? ' partial' : '' %>" style="margin-bottom: 0; table-layout: fixed;">
+<table class="reg table table-condensed <%= 'rjust' %><%= partial_byte ? ' partial' : '' %>" style="margin-bottom: 0; table-layout: fixed;">
   <thead>
     <tr class="bit-positions">
       <th class="spacer"></th>
+
 % 8.times do |i|
-%   if order_is_lsb0
-%     bit_num = (byte_number * 8) - i - 1
-%   else
-%     bit_num = (byte_index * 8) + i
-%   end
+%   bit_num = (byte_number * 8) - i - 1
 %   if bit_num > reg.size - 1
       <th class="spacer"></th>
 %   else
-      <th class="bit-position<%= !order_is_lsb0 && bit_num == reg.size - 1 ? ' last' : '' %>"><%= bit_num %></th>
+%     if order_is_lsb0
+      <th class="bit-position"><%= bit_num %></th>
+%     else
+      <th class="bit-position"><%= bit_num %><span class="msb0_specific"> (<%= reg.size - bit_num -1%>)</span></th>
+%     end
 %   end
 % end
     </tr>
@@ -78,8 +82,13 @@
 %#  Read Row
 %#############################################    
     <tr class="read">
+% if order_is_lsb0
       <td class="heading">R</td>
-% alignment_done = !order_is_lsb0
+% else
+      <td class="heading">R<span class="msb0_specific"> [LSB0]</span></td>
+% end
+
+% alignment_done = false
 % reg.named_bits :include_spacers => true do |name, bit|
 %  if _bit_in_range?(bit, max_bit, min_bit)
 %   if max_bit > (reg.size - 1) && !alignment_done
@@ -145,7 +154,7 @@
 %#############################################    
     <tr class="write">
       <td class="heading">W</td>
-% alignment_done = !order_is_lsb0
+% alignment_done = false
 % reg.named_bits :include_spacers => true do |name, bit|
 %  if _bit_in_range?(bit, max_bit, min_bit)
 %   if max_bit > (reg.size - 1) && !alignment_done
@@ -246,7 +255,7 @@
 %#############################################    
     <tr class="reset">
       <td class="heading">Reset</td>
-%   alignment_done = !order_is_lsb0
+%   alignment_done = false
 %   reg.named_bits :include_spacers => true do |name, bit|
 %   if _bit_in_range?(bit, max_bit, min_bit)
 %     if max_bit > (reg.size - 1) && !alignment_done

--- a/templates/shared/_register.html.erb
+++ b/templates/shared/_register.html.erb
@@ -14,19 +14,12 @@
 %   reg_path = reg.name
 % end
 % if reg.full_name
-%   if order_is_lsb0
 <h4>0x<%= reg.address.to_s(16).upcase %> - <%= reg.full_name %> (<%= reg_path %>)</h4>
-%   else
-<h4>0x<%= reg.address.to_s(16).upcase %> - <%= reg.full_name %> (<%= reg_path %>)<span class="msb0_specific"> <%= "#{reg_path}.with_msb0"%>(to access using MSB0 numbering)</span></h4>
-%   end
 % else
-%   if order_is_lsb0
 <h4>0x<%= reg.address.to_s(16).upcase %> - <%= reg_path %></h4>
-%   else
-<h4>0x<%= reg.address.to_s(16).upcase %> - <%= reg_path %><span class="msb0_specific"> <%= "#{reg_path}.with_msb0"%>(to access using MSB0 numbering)</span></h4>
-%   end
 % end
 </a>
+
 % if options[:current_value]
 %   if reg.size <= 8
 <h4><font style="background-color: #66FF66">Current Value: <%= sprintf("0x%02X",reg.value) %></font></h4>
@@ -47,6 +40,16 @@
 % end
 
 </div>
+% end
+
+% if !order_is_lsb0
+<table class="reg table table-condensed ljust" style="margin-bottom: 0; table-layout: fixed;">
+  <thead>
+    <tr class="bit-positions">
+      <b><tr class = "heading"><%= reg_path%> <span class="msb0_specific" style="color:gray;">(<%= reg_path %>.with_msb0)</span></tr></b>
+    </tr>
+  </thead>
+</table>
 % end
 
 % num_bytes = (reg.size / 8.0).ceil

--- a/templates/shared/_register.html.erb
+++ b/templates/shared/_register.html.erb
@@ -63,7 +63,7 @@
 % if order_is_lsb0
       <th class="spacer"></th>
 % else
-      <td class="heading">LSB0<span class="msb0_specific" style="color:red;"> (MSB0)</span></td>
+      <td class="heading">LSB0<span class="msb0_specific" style="color:gray;"> (MSB0)</span></td>
 % end
 
 % 8.times do |i|
@@ -74,7 +74,7 @@
 %     if order_is_lsb0
       <th class="bit-position"><%= bit_num %></th>
 %     else
-      <th class="bit-position"><%= bit_num %><span class="msb0_specific" style="color:red;"> (<%= reg.size - bit_num -1%>)</span></th>
+      <th class="bit-position"><%= bit_num %><span class="msb0_specific" style="color:gray;"> (<%= reg.size - bit_num -1%>)</span></th>
 %     end
 %   end
 % end
@@ -89,7 +89,7 @@
 % if order_is_lsb0
       <td class="heading">R</td>
 % else
-      <td class="heading"><span class="msb0_specific" style="color:red;">[LSB0] </span>R</td>
+      <td class="heading"><span class="msb0_specific" style="color:gray;">[LSB0] </span>R</td>
 % end
 
 % alignment_done = false


### PR DESCRIPTION
This is the companion PR for https://github.com/Origen-SDK/origen/pull/311

Registers defined with MSB0 numbering will now be displayed with their Origen native LSB0 numbering (default interpretation) AND also the MSB0 numbering. Information on how to access the bits by MSB0 numbers is included. All MSB0 specific information is displayed in gray.

I will send an email to internal NXP folks with a link to a local web serve with these updates. External folks can clone this branch and run 'origen web compile'. Navigate to Helpers -> Register Descriptions then scroll down to find MSB0 registers displayed.

Example snapshot:
![image](https://user-images.githubusercontent.com/17879450/49807545-f7eb3300-fd1f-11e8-996c-87909577d26e.png)
