### PR TITLE
Updated web links to origen-sdk.org to use HTTPS protocol due to

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,5 +9,5 @@ many typical Origen documentation scenarios.
 
 Additional contributions are welcome, please add examples for any new features.
 
-See the [examples on the website](http://origen-sdk.org/doc_helpers/examples) for
+See the [examples on the website](https://origen-sdk.org/doc_helpers/examples) for
 more information.

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,7 +8,7 @@ class OrigenDocHelpersApplication < Origen::Application
   # To enable deployment of your documentation to a web server (via the 'origen web'
   # command) fill in these attributes.
   config.web_directory = "git@github.com:Origen-SDK/Origen-SDK.github.io.git/doc_helpers"
-  config.web_domain = "http://origen-sdk.org/doc_helpers"
+  config.web_domain = "https://origen-sdk.org/doc_helpers"
   config.disqus_shortname = "origen-sdk"
 
   config.semantically_version = true

--- a/lib/origen_doc_helpers/guide_index.rb
+++ b/lib/origen_doc_helpers/guide_index.rb
@@ -1,7 +1,7 @@
 module OrigenDocHelpers
   # Provides an API to programatically construct an index hash as used
   # by the Searchable Documents helper -
-  # http://origen-sdk.org/doc_helpers/helpers/searchable/intro/#The_Document_Index
+  # https://origen-sdk.org/doc_helpers/helpers/searchable/intro/#The_Document_Index
   class GuideIndex
     def initialize
       @index = {}

--- a/origen_doc_helpers.gemspec
+++ b/origen_doc_helpers.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.authors       = ["Stephen McGinty"]
   spec.email         = ["stephen.f.mcginty@gmail.com"]
   spec.summary       = "Snippets and helpers for creating Origen web documents"
-  spec.homepage      = "http://origen-sdk.org/doc_helpers"
+  spec.homepage      = "https://origen-sdk.org/doc_helpers"
   spec.license       = 'MIT'
   spec.required_ruby_version     = '>= 1.9.3'
   spec.required_rubygems_version = '>= 1.8.11'

--- a/templates/model_index.md.erb
+++ b/templates/model_index.md.erb
@@ -3,7 +3,7 @@
 
 <div class="row" style="margin-top: 10px; margin-bottom: 15px;">
   <div class="col-md-9">
-    <img src="http://origen-sdk.org/img/origen-device.png" style="float: left; height:50px; width: 50px; margin-top: 14px;">
+    <img src="https://origen-sdk.org/img/origen-device.png" style="float: left; height:50px; width: 50px; margin-top: 14px;">
     <h1 style="float: left; margin-left: 10px;">Models</h1>
   </div>
 </div>

--- a/templates/model_page.md.erb
+++ b/templates/model_page.md.erb
@@ -20,7 +20,7 @@
 
 <div class="row" style="margin-top: 10px; margin-bottom: 15px;">
   <div class="col-md-9">
-    <img src="http://origen-sdk.org/img/origen-device.png" style="float: left; height:50px; width: 50px; margin-top: 14px;">
+    <img src="https://origen-sdk.org/img/origen-device.png" style="float: left; height:50px; width: 50px; margin-top: 14px;">
     <h1 style="float: left; margin-left: 10px;"><%= opts[:heading] %></h1>
   </div>
 % if opts[:search_box]

--- a/templates/web/helpers.md.erb
+++ b/templates/web/helpers.md.erb
@@ -16,7 +16,7 @@ These helpers will generate complete web pages for you.
 
 The following are components that you can embed within your own web pages.
 
-| [Searchable Documents](<%= path "/helpers/searchable/intro" %>) | Provides a layout for a guides section of your website, complete with search box (the [Origen Guides](http://origen-sdk.org/guides) uses this)
+| [Searchable Documents](<%= path "/helpers/searchable/intro" %>) | Provides a layout for a guides section of your website, complete with search box (the [Origen Guides](https://origen-sdk.org/guides) uses this)
 | [Register Descriptions](<%= path "/helpers/register" %>)        | Create a tabular register view, similar to that used in device reference manuals
 | [Yammer Comments](<%= path "/helpers/yammer" %>)                | Embed a comments section at the bottom of your page using Yammer
 | [Disqus Comments](<%= path "/helpers/disqus" %>)                | Embed a comments section at the bottom of your page using Disqus

--- a/templates/web/helpers/model.md.erb
+++ b/templates/web/helpers/model.md.erb
@@ -5,9 +5,9 @@
 This helper will build a collection of web pages that document a model's attributes,
 currently this includes its sub-blocks and registers.
 
-[Here is an example](http://origen-sdk.org/link_demo/models/linkdemo_toplevel/).
+[Here is an example](https://origen-sdk.org/link_demo/models/linkdemo_toplevel/).
 
-Multiple models can be supplied and an [index page like this](http://origen-sdk.org/link_demo/models)
+Multiple models can be supplied and an [index page like this](https://origen-sdk.org/link_demo/models)
 is generated to help locate the documentation for a given model.
 
 The collection of pages associated with a particular model is also fully searchable via

--- a/templates/web/helpers/register.md.erb
+++ b/templates/web/helpers/register.md.erb
@@ -2,7 +2,7 @@
 
 # Register Helpers
 
-Use the [Origen register API](http://origen-sdk.org/origen/guides/models/registers)
+Use the [Origen register API](https://origen-sdk.org/origen/guides/models/registers)
 to define registers in the normal way,
 all of the examples are here are based on this register definition:
 


### PR DESCRIPTION
Due to origen-sdk.org change to use https, had to change all hyperlink references to origen-sdk.org to use https.