### PR TITLE
rescue for mismatched drive issue in Windows

### DIFF
--- a/lib/origen_doc_helpers/helpers.rb
+++ b/lib/origen_doc_helpers/helpers.rb
@@ -272,12 +272,11 @@ END
             if options[:tab]
               options[:tab]
             else
-              rel = '..'
-              begin
-                rel = options[:top_level_file].relative_path_from(_doc_root_dir(options)).sub_ext('').sub_ext('').to_s
-              rescue
-                rel = '..'
-              end
+              rel = begin
+                  options[:top_level_file].relative_path_from(_doc_root_dir(options)).sub_ext('').sub_ext('').to_s
+                rescue
+                  '..'
+                end
               # If the file lives outside of the current app (e.g. it comes from a plugin), then the above approach
               # doesn't work, so let's just take the last dirname and the filename
               if rel =~ /\.\./

--- a/lib/origen_doc_helpers/helpers.rb
+++ b/lib/origen_doc_helpers/helpers.rb
@@ -272,7 +272,12 @@ END
             if options[:tab]
               options[:tab]
             else
-              rel = options[:top_level_file].relative_path_from(_doc_root_dir(options)).sub_ext('').sub_ext('').to_s
+              rel = '..'
+              begin
+                rel = options[:top_level_file].relative_path_from(_doc_root_dir(options)).sub_ext('').sub_ext('').to_s
+              rescue
+                rel = '..'
+              end
               # If the file lives outside of the current app (e.g. it comes from a plugin), then the above approach
               # doesn't work, so let's just take the last dirname and the filename
               if rel =~ /\.\./


### PR DESCRIPTION
This update is to prevent the Github Actions web compile check from crashing in Windows. The relative path call will generate a run time error if origen is running on a different drive letter than the file being compiled.

See https://github.com/Origen-SDK/origen/compare/WinGAWebCompile
