### PR TITLE
Issue21

### DIFF
--- a/lib/origen_doc_helpers/model_page_generator.rb
+++ b/lib/origen_doc_helpers/model_page_generator.rb
@@ -4,6 +4,7 @@ module OrigenDocHelpers
       attr_accessor :layout_options
       attr_accessor :layout
       attr_reader :pages
+      attr_accessor :target_as_id
 
       def run(options)
         @pages = {}
@@ -148,11 +149,20 @@ module OrigenDocHelpers
     end
 
     def id
-      @id ||= model.class.to_s.symbolize.to_s.gsub('::', '_')
+      if :target_as_id
+        @id ||= "#{Origen.target.name.downcase}" # _#{model.class.to_s.symbolize.to_s.gsub('::', '_')}"
+      else
+        @id ||= model.class.to_s.symbolize.to_s.gsub('::', '_')
+      end
     end
 
     def heading
-      model.class.to_s
+      if :target_as_id
+        @id.upcase
+        # Origen.target.name.to_s.upcase
+      else
+        model.class.to_s
+      end
     end
 
     def output_path

--- a/lib/origen_doc_helpers/model_page_generator.rb
+++ b/lib/origen_doc_helpers/model_page_generator.rb
@@ -159,7 +159,6 @@ module OrigenDocHelpers
     def heading
       if :target_as_id
         @id.upcase
-        # Origen.target.name.to_s.upcase
       else
         model.class.to_s
       end

--- a/templates/web/helpers/model.md.erb
+++ b/templates/web/helpers/model.md.erb
@@ -79,6 +79,9 @@ end
 
 * <code>:model</code> - **Required**, supply an instance of the model
 * <code>:group</code> - Optional, a heading to group similar models under on the index page, e.g. "Production", "In Development"
+* <code>:target_as_id</code> - Optional, causes the target name to be used for model page headings instead of the top-level model class name, 
+  e.g. "Eagle" instead of "MyApp::ModelA".  This is particularly useful if multiple targets instantiate the same top-level model with different
+  options or attributes that lead to differentiation.
 
 ## Website Integration
 


### PR DESCRIPTION
Update that allows for unique model documentation per-target when a top-level model is instantiated by multiple targets, each with potentially unique model configuration information within (ex: content managed by an options hash passed to the top-level model).  I was unsure if forcing this change on every user was appropriate, so I created the :target_as_id option.

Note: this is not recursive past the top level, so multiple instantiations of a lower level model with differentiating options is not yet handled.