### PR TITLE
Corrected for app dir structure - take 2

### DIFF
--- a/lib/origen_doc_helpers/flow_page_generator.rb
+++ b/lib/origen_doc_helpers/flow_page_generator.rb
@@ -43,12 +43,8 @@ module OrigenDocHelpers
         File.write(f, t)
       end
 
-      def index_page_template
-        if File.exist?("#{Origen.root}/app/")
-          @index_page_template ||= "#{Origen.root!}/app/templates/flow_index.md.erb"
-        else
-          @index_page_template ||= "#{Origen.root!}/templates/flow_index.md.erb"
-        end
+      def index_page_template # index page template is in doc helpers, which isn't using app/ dir
+        @index_page_template ||= "#{Origen.root!}/templates/flow_index.md.erb"
       end
     end
 
@@ -103,20 +99,12 @@ module OrigenDocHelpers
       d
     end
 
-    def flow_page_template
-      if File.exist?("#{Origen.root}/app/")
-        @flow_page_template ||= "#{Origen.root!}/app/templates/flow_page.md.erb"
-      else
-        @flow_page_template ||= "#{Origen.root!}/templates/flow_page.md.erb"
-      end
+    def flow_page_template # flow page template is in doc helpers, which isn't using app/ dir
+      @flow_page_template ||= "#{Origen.root!}/templates/flow_page.md.erb"
     end
 
-    def flow_template
-      if File.exist?("#{Origen.root}/app/")
-        @flow_template ||= "#{Origen.root!}/app/templates/shared/test/_flow.md.erb"
-      else
-        @flow_template ||= "#{Origen.root!}/templates/shared/test/_flow.md.erb"
-      end
+    def flow_template # flow template is in doc helpers, which isn't using app/ dir
+      @flow_template ||= "#{Origen.root!}/templates/shared/test/_flow.md.erb"
     end
   end
 end

--- a/lib/origen_doc_helpers/model_page_generator.rb
+++ b/lib/origen_doc_helpers/model_page_generator.rb
@@ -43,12 +43,8 @@ module OrigenDocHelpers
         File.write(f, t)
       end
 
-      def index_page_template
-        if File.exist?("#{Origen.root}/app/")
-          @index_page_template ||= "#{Origen.root!}/app/templates/model_index.md.erb"
-        else
-          @index_page_template ||= "#{Origen.root!}/templates/model_index.md.erb"
-        end
+      def index_page_template # index page template is in doc helpers, which isn't using app/ dir
+        @index_page_template ||= "#{Origen.root!}/templates/model_index.md.erb"
       end
     end
 
@@ -168,12 +164,8 @@ module OrigenDocHelpers
       "models/#{id}"
     end
 
-    def model_page_template
-      if File.exist?("#{Origen.root}/app/")
-        @model_page_template ||= "#{Origen.root!}/app/templates/model_page.md.erb"
-      else
-        @model_page_template ||= "#{Origen.root!}/templates/model_page.md.erb"
-      end
+    def model_page_template # model page template is in doc helpers, which isn't using app/ dir
+      @model_page_template ||= "#{Origen.root!}/templates/model_page.md.erb"
     end
   end
 end


### PR DESCRIPTION
Last time (https://github.com/Origen-SDK/origen_doc_helpers/pull/20) I did the 'fix' to support the `app/` dir structure, didn't realize that some of the templates were coming locally from origen_doc_helpers itself.  These related to flow and model page generation which were not evident using a relatively new Origen app with the `app/` dir structure.

This has now been corrected and this has been confirmed to work using a much more complex project that uses the `app/` dir structure.